### PR TITLE
Allow arbor to deal with a single node.

### DIFF
--- a/src/physics/physics.js
+++ b/src/physics/physics.js
@@ -205,6 +205,11 @@
       
       applyBarnesHutRepulsion:function(){
         if (!_bounds.topleft || !_bounds.bottomright) return
+        var nParticles = 0;
+         for (var particle in active.particles)
+            nParticles++;
+         if (nParticles < 2) return
+         
         var bottomright = new Point(_bounds.bottomright)
         var topleft = new Point(_bounds.topleft)
 
@@ -248,7 +253,7 @@
           numParticles++
         });
 
-        if (numParticles==0) return
+        if (numParticles < 2) return
         
         var correction = centroid.divide(-numParticles)
         $.each(active.particles, function(id, point) {
@@ -314,7 +319,8 @@
         });
         
         _energy = {sum:sum, max:max, mean:sum/n, n:n}
-        _bounds = {topleft:topleft||new Point(-1,-1), bottomright:bottomright||new Point(1,1)}
+        if (n > 1)
+          _bounds = {topleft:topleft||new Point(-1,-1), bottomright:bottomright||new Point(1,1)}
       },
 
       systemEnergy:function(timestep){


### PR DESCRIPTION
Made changes so that arbor can deal with a single node. There are 3 different changes, all in physics.js:

1) Barnes-Hut was getting in an infinite loop with a single node. It was not even possible to add more nodes. Now Barnes-Hut does nothing when there are less than two nodes.
2) A single node used to jitter, but now applyCenterDrift does nothing for less than two nodes.
3) The bounding box would get reduced to a point for a single node, but now the bounding box is unchanged for less two nodes.
