### PR TITLE
Semicolon patch

### DIFF
--- a/lib/arbor-tween.js
+++ b/lib/arbor-tween.js
@@ -78,9 +78,4 @@
     }
   })
   
-})(this.jQuery)
-
-
-
-
- 
+})(this.jQuery);

--- a/lib/arbor.js
+++ b/lib/arbor.js
@@ -64,4 +64,4 @@
     }
   })
   
-})(this.jQuery)
+})(this.jQuery);


### PR DESCRIPTION
Added semicolons at the end of arbor.js and arbor-tween.js. Without them, an exception gets thrown when the files are concatenated.
