### PR TITLE
Implement '\' escape sequence for demo halfviz's HalfTone language

### DIFF
--- a/demos/halfviz/index.html
+++ b/demos/halfviz/index.html
@@ -36,8 +36,9 @@
            is read line-by-line and matched for patterns of the form:</p>
         <code class='block'><em>name1</em> -&gt; <em>name2</em></code>
         <p>The names can be single or multiple words and can include digits, punctuation, or
-           space characters. Avoid using curly braces <code>{}</code> since those characters are used in styling
-           the graph.</p>
+           space characters. </p>
+        <p>Add escape character <code>\</code> before using curly braces <code>{}</code> like <code>\{whatever\}</code> since those characters are used in styling the graph.</p>
+        <p>Use <code>\\</code> to get single <code>\</code>.</p>
         <h3>lone nodes</h3>
         <p>If you want to create a node without connecting it to any of the others, simply list it
            on a line by itself: </p>

--- a/demos/halfviz/src/parseur.js
+++ b/demos/halfviz/src/parseur.js
@@ -59,11 +59,19 @@
       }
 
       s = s.replace(/([ \t]*)?;.*$/,'') // screen out comments
-
+      // Keep track on escape character '\'
+      var escaping = false;
       for (var i=0, j=s.length;;){
         var c = s[i]
         if (c===undefined) break
-        if (c=='-'){
+        // Start escaping
+        if (!escaping && c == '\\') {
+            // Skip escape character
+            escaping = true;
+            i++;
+            continue;
+        }
+        if (!escaping && c=='-'){
           if (s[i+1]=='>' || s[i+1]=='-'){
             flush()
             var edge = s.substr(i,2)
@@ -73,7 +81,7 @@
             buf += c
             i++
           }
-        }else if (c=='{'){
+        }else if (!escaping && c=='{'){
           var objStr = recognize(s.substr(i))
           if (objStr.length==0){
             buf += c
@@ -88,6 +96,8 @@
           }
         }else{
           buf += c
+          // Escape one character, that enough
+          if (escaping) escaping = false;
           i++
         }
         if (i>=j){


### PR DESCRIPTION
Current parser implementation forbid users from using curly braces `{` and `}`. This PR addresses that issue by add `\` escape sequence syntax to HalfTone language. Now user can use whatever he/she wants to name a node.
- Use `\{whatever\}` will get `{whatever}`
- Use `Backslash please don't escape from me. \\` will get `Backslash please don't escape from me. \`
