### PR TITLE
Add missing barnes-hut.js to source files listing.

### DIFF
--- a/docs/sample-project/index.html
+++ b/docs/sample-project/index.html
@@ -20,6 +20,7 @@
        <script src="../../src/graphics/graphics.js"></script>
        <script src="../../src/tween/easing.js"></script>
        <script src="../../src/tween/tween.js"></script>
+       <script src="../../src/physics/barnes-hut.js"></script>
        <script src="../../src/physics/atoms.js"></script>
        <script src="../../src/physics/physics.js"></script>
        <script src="../../src/physics/system.js"></script>


### PR DESCRIPTION
Looks like samizdatco missed a barnes-hut.js include. Fixed: "run from the original source files" now works as expected. Previously it'd throw an error and die. (Had to use the default minified library file.)
