### PR TITLE
docs: Fix simple typo, vizualization -> visualization

### DIFF
--- a/build/tmpl/arbor-full.js
+++ b/build/tmpl/arbor-full.js
@@ -1,6 +1,6 @@
 //
 //  arbor.js
-//  a graph vizualization toolkit
+//  a graph visualization toolkit
 //
 {{LICENSE}}
 

--- a/build/tmpl/arbor.js
+++ b/build/tmpl/arbor.js
@@ -1,6 +1,6 @@
 //
 //  arbor.js - version 0.91
-//  a graph vizualization toolkit
+//  a graph visualization toolkit
 //
 {{LICENSE}}
 

--- a/lib/arbor.js
+++ b/lib/arbor.js
@@ -1,6 +1,6 @@
 //
 //  arbor.js - version 0.91
-//  a graph vizualization toolkit
+//  a graph visualization toolkit
 //
 //  Copyright (c) 2012 Samizdat Drafting Co.
 //  Physics code derived from springy.js, copyright (c) 2010 Dennis Hotson


### PR DESCRIPTION
There is a small typo in build/tmpl/arbor-full.js, build/tmpl/arbor.js, lib/arbor.js.

Should read `visualization` rather than `vizualization`.

